### PR TITLE
Add offline tile caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # Pinchos
 Tool to map where to find Pinchos in Puerto Rico 🇵🇷.
+
+## Offline Usage
+The service worker caches map tiles under the `/tiles/` path. When a tile is requested,
+`sw.js` checks if it exists in the `tiles-cache`. Missing tiles are fetched from the
+network, stored in the cache, and then returned. Subsequent requests for the same tile
+are served directly from the cache so basic map browsing continues to work offline.

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,0 +1,18 @@
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (url.pathname.startsWith('/tiles/')) {
+    event.respondWith(
+      caches.open('tiles-cache').then(cache => {
+        return cache.match(event.request).then(response => {
+          if (response) {
+            return response;
+          }
+          return fetch(event.request).then(networkResponse => {
+            cache.put(event.request, networkResponse.clone());
+            return networkResponse;
+          });
+        });
+      })
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- create a service worker to cache `/tiles/` requests
- document tile caching behavior for offline use

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c2c1488bc832588e7a9cae9792188