### PR TITLE
Add data import/export and tile caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # Pinchos
-Tool to map where to find Pinchos in Puerto Rico 🇵🇷.
+
+A simple offline-first PWA to map food stands and other points of interest in Puerto Rico.
+
+## Features
+
+- Map view centered on Puerto Rico using Leaflet.
+- Add markers by tapping on the map. Locations are stored in `localStorage` for offline use.
+- Service worker caches the application shell, Leaflet library, and any map tiles you view for true offline access.
+- Designed to work with locally stored map tiles placed in the `app/tiles` directory.
+
+## Getting Started
+
+1. Install a local HTTP server. For example, with Python:
+
+   ```bash
+   python3 -m http.server -b 0.0.0.0 -d app 8000
+   ```
+
+2. Open `http://localhost:8000` in your browser. The first load requires internet
+   access to fetch Leaflet from the CDN. After that, the service worker caches
+   everything for offline use.
+
+3. To add offline map tiles, create a `tiles/{z}/{x}/{y}.png` structure inside
+   the `app` directory. You can generate MBTiles for Puerto Rico and export them
+   as PNG tiles using tools like [TileMill](https://tilemill-project.github.io/)
+   or [MBUtil](https://github.com/mapbox/mbutil).
+
+## Data Import/Export
+
+Use the **Export** button to download your saved locations as `locations.json`.
+You can load a file created this way with the **Import** button on another
+device. The imported locations replace your current list and are saved back to
+`localStorage`.
+
+## License
+
+This project is licensed under the Apache 2.0 License. See the `LICENSE` file
+for details.

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pinchos Map</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" integrity="sha384-gZwIG9x3wUXgLNC5uEk1FTAkusTztwWkeFAjLkn3gtwEwZiZVr4FEyceHuxgwrx3" crossorigin="" />
+    <style>
+        html, body { height: 100%; margin: 0; }
+        #map { width: 100%; height: 100%; }
+        #controls {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            z-index: 1000;
+            background: rgba(255, 255, 255, 0.8);
+            padding: 4px;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <div id="controls">
+        <button id="exportBtn">Export</button>
+        <button id="importBtn">Import</button>
+        <input type="file" id="importFile" accept="application/json" style="display:none" />
+    </div>
+    <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js" integrity="sha384-o9N1jJN1d1q8fFhk9ZUJq5hFiBPD3j+zGyZ/Fw5r6uCW1n61vuH0PeJ4okfktQHI" crossorigin=""></script>
+    <script src="map.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', function() {
+                navigator.serviceWorker.register('sw.js');
+            });
+        }
+    </script>
+</body>
+</html>

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,0 +1,8 @@
+{
+    "name": "Pinchos Map",
+    "short_name": "Pinchos",
+    "start_url": "./index.html",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "description": "Offline map to locate Pinchos in Puerto Rico"
+}

--- a/app/map.js
+++ b/app/map.js
@@ -1,0 +1,73 @@
+// Initialize Leaflet map
+var map = L.map('map').setView([18.2208, -66.5901], 9); // Center on Puerto Rico
+
+// Tile layer from local tiles directory
+var offlineLayer = L.tileLayer('./tiles/{z}/{x}/{y}.png', {
+    maxZoom: 18,
+    minZoom: 5,
+    errorTileUrl: '',
+    attribution: 'Map data &copy; OpenStreetMap contributors'
+}).addTo(map);
+
+// Load saved points of interest from localStorage
+var locations = JSON.parse(localStorage.getItem('locations') || '[]');
+var markers = [];
+locations.forEach(function(loc) {
+    var m = L.marker([loc.lat, loc.lng]).addTo(map).bindPopup(loc.name);
+    markers.push(m);
+});
+
+// Add marker on map click and store in localStorage
+map.on('click', function(e) {
+    var name = prompt('Name of location');
+    if (!name) return;
+    var marker = L.marker(e.latlng).addTo(map).bindPopup(name);
+    markers.push(marker);
+    locations.push({ lat: e.latlng.lat, lng: e.latlng.lng, name: name });
+    localStorage.setItem('locations', JSON.stringify(locations));
+});
+
+// Export locations as JSON file
+document.getElementById('exportBtn').addEventListener('click', function() {
+    var data = JSON.stringify(locations, null, 2);
+    var blob = new Blob([data], { type: 'application/json' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'locations.json';
+    a.click();
+    URL.revokeObjectURL(url);
+});
+
+// Import locations from JSON file
+document.getElementById('importBtn').addEventListener('click', function() {
+    document.getElementById('importFile').click();
+});
+
+document.getElementById('importFile').addEventListener('change', function(e) {
+    var file = e.target.files[0];
+    if (!file) return;
+    var reader = new FileReader();
+    reader.onload = function(evt) {
+        try {
+            var data = JSON.parse(evt.target.result);
+            if (Array.isArray(data)) {
+                // Remove existing markers
+                markers.forEach(function(m) { map.removeLayer(m); });
+                markers = [];
+                locations = data;
+                locations.forEach(function(loc) {
+                    var m = L.marker([loc.lat, loc.lng]).addTo(map).bindPopup(loc.name);
+                    markers.push(m);
+                });
+                localStorage.setItem('locations', JSON.stringify(locations));
+            } else {
+                alert('Invalid file');
+            }
+        } catch (err) {
+            alert('Failed to read file');
+        }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+});

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,0 +1,39 @@
+const CACHE_NAME = 'pinchos-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './map.js',
+  './manifest.json',
+  'https://unpkg.com/leaflet@1.9.3/dist/leaflet.css',
+  'https://unpkg.com/leaflet@1.9.3/dist/leaflet.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (url.pathname.startsWith('/tiles/')) {
+    event.respondWith(
+      caches.match(event.request).then(cached => {
+        if (cached) return cached;
+        return fetch(event.request).then(resp => {
+          return caches.open(CACHE_NAME).then(cache => {
+            cache.put(event.request, resp.clone());
+            return resp;
+          });
+        });
+      })
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add export and import buttons to the UI
- implement marker export/import logic in `map.js`
- cache tiles on first view using the service worker
- document new functionality in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687422bfb04c8325b2c6f0b974b8f5d9